### PR TITLE
Actually Fixed: change the image tag in compose.yml to new tag

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -202,20 +202,19 @@ pipeline {
         sshagent(credentials: ['ec2-ssh-key']) {
           script {
             sh """
-              ssh -o StrictHostKeyChecking=no ${REMOTE_USER}@${REMOTE_HOST} <<EOF
+              ssh -o StrictHostKeyChecking=no ${REMOTE_USER}@${REMOTE_HOST} <<'EOF'
                 set -e
                 aws ecr get-login-password --region ${AWS_REGION} | docker login --username AWS --password-stdin ${ECR_REGISTRY}
                 cd ${REMOTE_DIR}
 
-                sed -i "s|\$(grep fleetfinder-backend docker-compose.yml | grep image:)|  image: ${BACKEND_IMAGE_TAG}|" docker-compose.yml
-                sed -i "s|\$(grep fleetfinder-frontend docker-compose.yml | grep image:)|  image: ${FRONTEND_IMAGE_TAG}|" docker-compose.yml
+                sed -i "s|\$(grep fleetfinder-backend docker-compose.yml | grep image:)|    image: ${BACKEND_IMAGE_TAG}|" docker-compose.yml
+                sed -i "s|\$(grep fleetfinder-frontend docker-compose.yml | grep image:)|    image: ${FRONTEND_IMAGE_TAG}|" docker-compose.yml
 
                 docker-compose --env-file .env.prod pull
                 docker-compose --env-file .env.prod down
                 docker-compose --env-file .env.prod up -d
 
-                echo "DEBUG: \\\$(grep fleetfinder-backend docker-compose.yml | grep image:)|  image: ${BACKEND_IMAGE_TAG}|\\\" docker-compose.yml"
-              EOF
+              'EOF'
             """
           }
         }


### PR DESCRIPTION
Realized that one of these attempts to fix this did actually successfully pull the image tag and replace that line in the docker compose, but it failed the pipeline for a different reason so i did not realize it at the time. Found the commit for that and copied the EOF syntax into this. I think it failed because the closing 'EOF' was not in single quotes, the pipeline had an error that said something along the lines of ''EOF' delineated by end of file'. I am fairly confident that this one is actually going to work. I also adjusted the NGINX config to include the http_authorization in the header because so far the http requests to the backend have not included the JWTs necessary for provisioning users in the app database. I am hoping this has fixed that as well, but I am not sure.