### PR TITLE
fixes for notification_outbox unique key, chat panel display features…

### DIFF
--- a/backend/src/main/java/com/sc_fleetfinder/fleets/services/CRUD_services/HiddenListingServiceImpl.java
+++ b/backend/src/main/java/com/sc_fleetfinder/fleets/services/CRUD_services/HiddenListingServiceImpl.java
@@ -78,12 +78,11 @@ public class HiddenListingServiceImpl implements HiddenListingService {
         if(unHidden.isPresent()) {
             GroupListing temp = unHidden.get();
             String title = temp.getListingTitle();
-            response.put("Response", (title + " has been unhidden.").length() <= 20 ? title : title.substring(0,20) + "... has been unhidden.");
-            return ResponseEntity.status(HttpStatus.OK).body(response);
+            response.put("Response", (title + " has been unhidden.").length() >= 20 ? title : title.substring(0,20) + "... has been unhidden.");
         } else {
             response.put("Response", "No hidden listings");
-            return ResponseEntity.status(HttpStatus.OK).body(response);
         }
+        return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
     @Override

--- a/backend/src/main/resources/migration/V12__add_new_status_to_outbox_uq.sql
+++ b/backend/src/main/resources/migration/V12__add_new_status_to_outbox_uq.sql
@@ -1,0 +1,10 @@
+/* TODO move into the create table and set entity_new_status to not null */
+
+ALTER TABLE notification_outbox
+    DROP INDEX uq_note_outbox_event,
+    ADD UNIQUE KEY uq_note_outbox_event (
+        event_type,
+        entity_type,
+        entity_id,
+        entity_new_status
+    )

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -71,7 +71,7 @@ services:
       start_period: 90s
 
   backend:
-    image: 753149409316.dkr.ecr.us-west-2.amazonaws.com/fleetfinder-backend:cache_1750058484
+    image: 753149409316.dkr.ecr.us-west-2.amazonaws.com/fleetfinder-backend:cache_1767909255
     container_name: fleetfinder-backend
     restart: always
     environment:
@@ -80,6 +80,7 @@ services:
       DB_USERNAME: ${DB_USERNAME}
       DB_PASSWORD: ${DB_PASSWORD}
       DB_NAME: sc_fleetfinder
+      WS_ALLOWED_ORIGINS: ${WS_ALLOWED_ORIGINS}
       SPRING_PROFILES_ACTIVE: prod
     ports:
       - "8080:8080"
@@ -92,7 +93,7 @@ services:
       - backend-network
 
   frontend:
-    image: 753149409316.dkr.ecr.us-west-2.amazonaws.com/fleetfinder-frontend:cache_1750058484
+    image: 753149409316.dkr.ecr.us-west-2.amazonaws.com/fleetfinder-frontend:cache_1767909255
     container_name: fleetfinder-frontend
     restart: always
     depends_on:

--- a/deployment/nginx/conf.d/default.conf
+++ b/deployment/nginx/conf.d/default.conf
@@ -61,6 +61,18 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
   }
 
+  location /websocket {
+    proxy_pass http://backend:8080/websocket;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+
   location /.well-known/acme-challenge/ {
         root /var/www/certbot;
   }

--- a/frontend/angular-fleets/src/app/components/chat/chat-panel/chat-panel.component.css
+++ b/frontend/angular-fleets/src/app/components/chat/chat-panel/chat-panel.component.css
@@ -208,7 +208,8 @@
   margin-bottom: 3px;
   color: #478028;
 }
-.not-connected {
+
+#connected-icon.not-connected {
   color: #9a1919;
 }
 
@@ -318,7 +319,7 @@
   min-width: 0;
   border-radius: 3rem;
   font-size: clamp(0.8rem, 1.1rem, 1.8rem);
-  color: rgba(255, 131, 7, .5) !important;
+  color: rgba(255, 131, 7, .4) !important;
   line-height: 1;
   transition: transform 200ms ease;
   transform-origin: center;
@@ -340,10 +341,17 @@
   margin-right: 4px;
 }
 
+.tabs-button {
+  border: 1px solid rgba(255, 131, 7, .25);
+  border-radius: 4px;
+  height: 30px;
+  margin-top: 4px;
+}
+
 #tabs-label {
   align-self: center;
   font-size: 0.9rem;
-  padding-left: 8px;
+  padding-right: 8px;
   color: rgba(150, 168, 183, 1);
 }
 
@@ -542,6 +550,18 @@
 
   }
 
+  :host:not(.is-collapsed) .chat-border,
+  :host:not(.is-collapsed) .chat-panel {
+    clip-path: polygon(
+      8.5% 0%,     /* top edge, a bit right from TL */
+      100% 0%,   /* full top-right corner */
+      100% 90%,  /* right edge, a bit up from BR */
+      94% 100%,  /* bottom edge, a bit left from BR */
+      0% 100%,   /* full bottom-left corner */
+      0% 11.2%      /* left edge, a bit down from TL */
+    );
+  }
+
   :host(.is-collapsed) {
     z-index: 0;
   }
@@ -573,6 +593,18 @@
 @media(max-width: 410px) {
   :host {
     right: 1vw;
+  }
+
+  :host:not(.is-collapsed) .chat-border,
+  :host:not(.is-collapsed) .chat-panel {
+    clip-path: polygon(
+      8.75% 0%,     /* top edge, a bit right from TL */
+      100% 0%,   /* full top-right corner */
+      100% 90%,  /* right edge, a bit up from BR */
+      94% 100%,  /* bottom edge, a bit left from BR */
+      0% 100%,   /* full bottom-left corner */
+      0% 11.2%      /* left edge, a bit down from TL */
+    );
   }
 
   .chat-panel-wrapper {

--- a/frontend/angular-fleets/src/app/components/chat/chat-panel/chat-panel.component.html
+++ b/frontend/angular-fleets/src/app/components/chat/chat-panel/chat-panel.component.html
@@ -10,8 +10,8 @@
             <mat-icon class="dropdown-arrow">arrow_drop_down</mat-icon>
           </button>
         </div>
-        <ng-container *ngIf="(ws.isConnected$ | async) as isConnected" class="h-fill">
-          <mat-icon id="connected-icon" class="connected" [class.not-connected]="!isConnected">circle</mat-icon>
+        <ng-container *ngIf="(ws.isConnected$ | async) as isConnected">
+          <mat-icon id="connected-icon" class="h-fill" [class.not-connected]="!isConnected">circle</mat-icon>
         </ng-container>
         <div class="h-fill">
           <ng-container *ngIf="((ws.totalUnread$ | async) ?? 0) > 0; else waiting">
@@ -105,12 +105,13 @@
               <ng-container *ngIf="(chatLayoutMode$ | async) === 'handheld'">
                 <div class="tabs-button-container">
                   <button mat-button
+                          class="tabs-button"
                           (click)="drawer.toggle()">
+                    <label id="tabs-label">
+                      Conversations
+                    </label>
                     <label [class.tabs-button-rotated]="drawer.opened" class="conversation-tab-icon">
                       >>
-                    </label>
-                    <label id="tabs-label">
-                      Convs.
                     </label>
                   </button>
                 </div>

--- a/frontend/angular-fleets/src/app/components/chat/message-input/message-input.component.html
+++ b/frontend/angular-fleets/src/app/components/chat/message-input/message-input.component.html
@@ -3,6 +3,7 @@
     <div class="text-area-wrapper">
       <textarea
         matInput
+        #msgInput
         [formControl]="inputCtrl"
         cdkTextareaAutosize
         cdkAutosizeMinRows="1"

--- a/frontend/angular-fleets/src/app/components/chat/message-input/message-input.component.ts
+++ b/frontend/angular-fleets/src/app/components/chat/message-input/message-input.component.ts
@@ -1,4 +1,13 @@
-import {Component, DestroyRef, EventEmitter, inject, Output, ViewChild} from '@angular/core';
+import {
+  AfterViewChecked,
+  Component,
+  DestroyRef,
+  ElementRef,
+  EventEmitter,
+  inject,
+  Output,
+  ViewChild
+} from '@angular/core';
 import {FormControl, ReactiveFormsModule} from "@angular/forms";
 import {MatError, MatFormField, MatHint} from "@angular/material/form-field";
 import {MatInput} from "@angular/material/input";
@@ -27,8 +36,9 @@ import {takeUntilDestroyed} from "@angular/core/rxjs-interop";
   ],
   styleUrl: './message-input.component.css'
 })
-export class MessageInputComponent {
+export class MessageInputComponent implements AfterViewChecked {
   @ViewChild(CdkTextareaAutosize) autosize?: CdkTextareaAutosize;
+  @ViewChild('msgInput') msgInput?: ElementRef<HTMLElement>;
   ChatWindowState = ChatWindowState;
   private inputDestroyRef = inject(DestroyRef);
   protected isExpanding: boolean = false;
@@ -52,6 +62,12 @@ export class MessageInputComponent {
         this.isExpanding = true;
         setTimeout(() => this.isExpanding = false, 220);
       })
+  }
+
+  ngAfterViewChecked() {
+    if(this.msgInput) {
+      setTimeout(() => this.msgInput?.nativeElement.focus(), 300);
+    }
   }
 
   emitMessage(input: string | null) {

--- a/frontend/angular-fleets/src/app/components/group-listings/group-listings.component.html
+++ b/frontend/angular-fleets/src/app/components/group-listings/group-listings.component.html
@@ -21,28 +21,22 @@
       </th>
 
       <td mat-cell *matCellDef="let row; let i = index" class="indicators-column">
-        <!-- TODO this ngIf is just for demo to display the icon -->
-        <ng-container *ngIf="(row.availableRoles !== null) ; else noStatus">
-          <mat-icon
-            [matTooltip]="
+        <mat-icon
+          [matTooltip]="
                         row.visStatus === 'FRESH' ? 'Updated < 3 hours ago' :
                         row.visStatus === 'RECENT' ? 'Updated < 6 hours ago' :
                         row.visStatus === 'STALE' ? 'Updated < 12 hours ago or future event' :
                         row.visStatus === 'INACTIVE' ? 'Updated 12+ hours ago' :
                         'Unknown status'
                        "
-            [matTooltipPosition]="positionOptions[0]"
-            class="status-circle-icon"
-            [class.is-fresh]="row.visStatus === 'FRESH'"
-            [class.is-recent]="row.visStatus === 'RECENT'"
-            [class.is-stale]="row.visStatus === 'STALE'"
-            [class.is-inactive]="row.visStatus === 'INACTIVE'">
-            circle
-          </mat-icon>
-        </ng-container>
-        <ng-template #noStatus>
-          <mat-icon></mat-icon>
-        </ng-template>
+          [matTooltipPosition]="positionOptions[0]"
+          class="status-circle-icon"
+          [class.is-fresh]="row.visStatus === 'FRESH'"
+          [class.is-recent]="row.visStatus === 'RECENT'"
+          [class.is-stale]="row.visStatus === 'STALE'"
+          [class.is-inactive]="row.visStatus === 'INACTIVE'">
+          circle
+        </mat-icon>
         <ng-container *ngIf="(layoutMode$ | async) == 'full'">
           <ng-container *ngIf="listingInteract.bookmarkedIds$ | async as bookmarkIds">
               <button mat-icon-button *ngIf="listingInteract.isBookmarked(row.groupId, bookmarkIds) ; else notBookmarked"
@@ -199,18 +193,22 @@
       </th>
 
       <td mat-cell *matCellDef="let row; let i = index" class="indicators-column">
-        <ng-container *ngIf="!(row.availableRoles === null) ; else noStatus">
-          <mat-icon
-            matTooltip="ToDo: conversation status"
-            [matTooltipPosition]="positionOptions[0]"
-            class="status-circle-icon"
-            [class.has-response]="row.system === 'Stanton'"
-            [class.response-pending]="row.system === 'Pyro'">circle
-          </mat-icon>
-        </ng-container>
-        <ng-template #noStatus>
-          <mat-icon></mat-icon>
-        </ng-template>
+        <mat-icon
+          [matTooltip]="
+                        row.visStatus === 'FRESH' ? 'Updated < 3 hours ago' :
+                        row.visStatus === 'RECENT' ? 'Updated < 6 hours ago' :
+                        row.visStatus === 'STALE' ? 'Updated < 12 hours ago or future event' :
+                        row.visStatus === 'INACTIVE' ? 'Updated 12+ hours ago' :
+                        'Unknown status'
+                       "
+          [matTooltipPosition]="positionOptions[0]"
+          class="status-circle-icon"
+          [class.is-fresh]="row.visStatus === 'FRESH'"
+          [class.is-recent]="row.visStatus === 'RECENT'"
+          [class.is-stale]="row.visStatus === 'STALE'"
+          [class.is-inactive]="row.visStatus === 'INACTIVE'">
+          circle
+        </mat-icon>
       </td>
     </ng-container>
 

--- a/frontend/angular-fleets/src/app/components/input-fields/search-bar/search-bar.component.css
+++ b/frontend/angular-fleets/src/app/components/input-fields/search-bar/search-bar.component.css
@@ -309,6 +309,10 @@
     padding-bottom: 0.25rem !important;
   }
 
+  .search-clear {
+    padding-top: 8px;
+  }
+
   :host ::ng-deep .search-input .mat-mdc-floating-label.mdc-floating-label--float-above {
     margin-top: 0.25rem;
     font-size: 1rem;
@@ -508,7 +512,25 @@
   .mat-mdc-form-field {
     min-width: 95%;
   }
+  .search-clear {
+    padding-top: 8px;
+    height: 40px;
+  }
+
+  /* input field placeholder text?????? */
+  :host ::ng-deep .mat-mdc-form-field:hover:not(:focus-within) .mat-mdc-floating-label {
+    /*color: rgba(255, 131, 7, 0.4) !important;*/
+    padding-top: 8px;
+  }
 }
+
+@media(max-height: 699px) {
+  .search-clear {
+    padding-top: 4px;
+  }
+}
+
+
 
 /* label transition */
 :host ::ng-deep .mat-mdc-form-field .mat-mdc-floating-label {

--- a/frontend/angular-fleets/src/app/services/auth/auth-services/auth.service.ts
+++ b/frontend/angular-fleets/src/app/services/auth/auth-services/auth.service.ts
@@ -29,6 +29,7 @@ export class AuthService {
 );
 
   public readonly accessToken$ = this.oidc.getAccessToken().pipe(
+    filter((token): token is string => !!token),
     distinctUntilChanged(),
     shareReplay({ bufferSize: 1, refCount: true })
   )

--- a/frontend/angular-fleets/src/app/services/user-services/user.service.ts
+++ b/frontend/angular-fleets/src/app/services/user-services/user.service.ts
@@ -95,7 +95,7 @@ export class UserService {
       takeUntilDestroyed(this.destroyRef)
     ).subscribe(token => {
         if(token && !this.ws.isConnected()) {
-          this.ws.connect(token);
+          this.ws.connect();
         }
     });
   }

--- a/frontend/angular-fleets/src/app/services/websocket-messaging/ws-gateway.service.ts
+++ b/frontend/angular-fleets/src/app/services/websocket-messaging/ws-gateway.service.ts
@@ -1,10 +1,12 @@
-import { Injectable } from '@angular/core';
+import {DestroyRef, inject, Injectable} from '@angular/core';
 import {Client, StompSubscription} from "@stomp/stompjs";
 import {BehaviorSubject, Observable, Subject} from "rxjs";
 import {environment} from "../../../environments/environment";
 import {MessageViewModel} from "../../models/chat/message-view-model";
 import {ConversationViewModel} from "../../models/chat/conversation-view-model";
 import {NotificationViewModel} from "../../models/NotificationViewModel";
+import {AuthService} from "../auth/auth-services/auth.service";
+import {takeUntilDestroyed} from "@angular/core/rxjs-interop";
 
 export interface UnreadSummaryDto {
   totalUnread: number;
@@ -24,6 +26,7 @@ export interface NoteUnreadDto {
   providedIn: 'root'
 })
 export class WsGatewayService {
+  private wsDestroyRef = inject(DestroyRef);
 
   private client: Client | null = null;
 
@@ -55,7 +58,11 @@ export class WsGatewayService {
 
   private notificationStompSub: StompSubscription | null = null;
 
-  constructor() {
+  private latestAuthToken: string | null = null;
+
+  constructor(private auth: AuthService) {
+    this.auth.accessToken$.pipe(takeUntilDestroyed(this.wsDestroyRef)).subscribe(
+      latest => this.latestAuthToken = latest);
   }
 
   subscribe<T>(destination: string, handler: (body: T) => void): StompSubscription {
@@ -65,14 +72,14 @@ export class WsGatewayService {
     return this.client.subscribe(destination, (msg) => handler(JSON.parse(msg.body) as T));
   }
 
-  connect(token: string): void {
+  connect(): void {
     if(this.client?.active) return;
-    if(!token) return;
+    if(!this.latestAuthToken) return;
 
     this.client = new Client({
       webSocketFactory: () => new WebSocket(`${environment.wsBaseUrl}/websocket`),
       connectHeaders: {
-        Authorization: `Bearer ${token}`,
+        Authorization: `Bearer ${this.latestAuthToken}`,
       },
       reconnectDelay: 3000,
       heartbeatIncoming: 25000,
@@ -111,11 +118,18 @@ export class WsGatewayService {
       },
 
       onStompError: () => { console.error("STOMP ERROR") },
-      // debug: (s) => console.log(['stomp'], s),
+      debug: (s) => console.log(['stomp'], s),
       onWebSocketClose: () => {
         this.connectedSubject.next(false);
         this.chatUnreadStompSub?.unsubscribe();
         this.chatUnreadStompSub = null;
+
+        this.noteUnreadStompSub?.unsubscribe();
+        this.noteUnreadStompSub = null;
+
+        this.notificationStompSub?.unsubscribe();
+        this.notificationStompSub = null;
+
       }
     });
 


### PR DESCRIPTION
…, mobile listings table vis status colors, ws reconnect:

'undoLastHide' had a typo with the < reversed on length comparison. added entity_new_status to the unique key so that it will generate new outbox notes on each status change. removed token as parameter for ws connect and subscribed to access token observable from auth service for passing latest token. added vis status styling to mobile listing view table. Adjusted the convs button on mobile chat panel for clearer button styling, added styling in chat panel for not connected red icon for ws. Added set focus to msg input field in chat when it renders.