### PR TITLE
Troubleshooting android push subscription issues

### DIFF
--- a/backend/src/main/java/com/sc_fleetfinder/fleets/DAO/chat/MessageRepository.java
+++ b/backend/src/main/java/com/sc_fleetfinder/fleets/DAO/chat/MessageRepository.java
@@ -67,7 +67,7 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
                 AND channels.delivery_channel = 'PUSH'
                 AND push.social_notes_enabled = 1
             WHERE msg.id_msg = :msgId
-                AND (noti.created_at IS NULL OR noti.created_at < (NOW() - INTERVAL 5 MINUTE))
+                AND (noti.created_at IS NULL OR noti.created_at < (NOW() - INTERVAL 20 SECOND))
                 AND (parti.last_read_message_id IS NULL OR parti.last_read_message_id < :msgId)
                 AND (
                     (channels.delivery_channel = 'DISCORD'

--- a/backend/src/main/java/com/sc_fleetfinder/fleets/config/discord/DiscordBotServiceImpl.java
+++ b/backend/src/main/java/com/sc_fleetfinder/fleets/config/discord/DiscordBotServiceImpl.java
@@ -1,7 +1,7 @@
 package com.sc_fleetfinder.fleets.config.discord;
 
+import com.sc_fleetfinder.fleets.DAO.NotificationRepository;
 import com.sc_fleetfinder.fleets.entities.Notification;
-import com.sc_fleetfinder.fleets.utils.ExternalNotifcationResult;
 import com.sc_fleetfinder.fleets.utils.NotificationType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -9,12 +9,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.time.Instant;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -24,19 +22,20 @@ import java.util.Map;
 public class DiscordBotServiceImpl implements DiscordBotService {
 
     private final RestClient discordRestClient;
+    private final NotificationRepository notificationRepository;
 
     @Override
     public void sendDiscordNotification(String discordUserId, Notification note) {
         String channelId = openDmChannel(discordUserId);
         ResponseEntity<?> response = sendDmNotification(channelId, note);
 
-        Map<ExternalNotifcationResult, HttpStatus> messageStatus = new HashMap<>();
-
         if(response.getStatusCode() == HttpStatus.OK) {
-            messageStatus.put(ExternalNotifcationResult.SUCCESS, HttpStatus.OK);
             note.setReadAt(Instant.now());
         } else {
-            throw new ResponseStatusException(response.getStatusCode());
+            String message = "Failed to send push notification for user with ID: [" + note.getUser().getUserId()
+                    + "]. " + response.getBody();
+            notificationRepository.delete(note);
+            throw new ResponseStatusException(response.getStatusCode(), message);
         }
     }
 
@@ -106,14 +105,11 @@ public class DiscordBotServiceImpl implements DiscordBotService {
                 "embeds", List.of(embed)
         );
 
-        ResponseEntity<?> response = discordRestClient.post()
+        return discordRestClient.post()
                 .uri("/channels/{channelId}/messages", channelId)
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(body)
                 .retrieve()
                 .toBodilessEntity();
-
-        log.info(response.toString());
-        return response;
     }
 }

--- a/backend/src/main/java/com/sc_fleetfinder/fleets/messaging/push/PushNotificationService.java
+++ b/backend/src/main/java/com/sc_fleetfinder/fleets/messaging/push/PushNotificationService.java
@@ -48,6 +48,8 @@ public class PushNotificationService {
             HttpStatus status = HttpStatus.valueOf(response.getStatusLine().getStatusCode());
             result.put(ExternalNotifcationResult.FAILURE, status);
         }
+
+        log.warn("PUSH SUBSCRIPTION SEND RESULT: {} \n PUSH SUBSCRIPTION RESPONSE LINE: {}", result, response);
         return result;
     }
 }

--- a/backend/src/main/java/com/sc_fleetfinder/fleets/services/CRUD_services/NotificationServiceImpl.java
+++ b/backend/src/main/java/com/sc_fleetfinder/fleets/services/CRUD_services/NotificationServiceImpl.java
@@ -216,7 +216,7 @@ public class NotificationServiceImpl implements NotificationService {
     }
 
     private void sendPushNotification(Notification note, PushSubscription pushSub) {
-        String payload = note.getTitle() + "'" + note.getMessage() + "'";
+        String payload = note.getTitle() + " '" + note.getMessage() + "'";
 
         try {
             Map<ExternalNotifcationResult, HttpStatus> pushResult = pushNotificationService.sendPushNotification(pushSub, payload);
@@ -228,18 +228,17 @@ public class NotificationServiceImpl implements NotificationService {
                 throw new ResponseStatusException(pushResult.get(ExternalNotifcationResult.FAILURE));
             }
         } catch (Exception e) {
-            note.getOutbox().setLastError("Failed to send push notification for push subscription with ID: "
-                    + pushSub.getIdPushSub() + ", and notification outbox ID: " + note.getOutbox().getOutboxId()
-                    + ", and notification ID: " + note.getNotificationId() + " \n" + e.getMessage());
-            note.getOutbox().setStatus("PARTIAL_FAILURE");
-            outboxRepo.save(note.getOutbox());
+            String error = "Failed to send push notification for push subscription with ID: "
+                    + pushSub.getIdPushSub() + ". ERROR:" + e.getMessage();
+            notificationRepo.delete(note);
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, error);
         }
     }
 
     // SEND DISCORD NOTIFICATION is in config/discord/DiscordBotService
 
     private Notification buildNewMessageNotification(NotificationOutbox obEntity) {
-        String title = "You have a new message from ";
+        String title = "New message from ";
         Message message = msgRepo.findMessageByConversationIdAndMessageId(
                 obEntity.getParentEntityId(), obEntity.getEntityId())
                 .orElse(null);

--- a/backend/src/test/java/com/sc_fleetfinder/fleets/unit_tests/services/CRUD_services/NotificationServiceImplTest.java
+++ b/backend/src/test/java/com/sc_fleetfinder/fleets/unit_tests/services/CRUD_services/NotificationServiceImplTest.java
@@ -41,6 +41,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -51,6 +52,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -547,7 +549,7 @@ class NotificationServiceImplTest {
     }
 
     @Test
-    void prepareAndSendOutboxNotification_PushDelivery_Failure_LogsOutboxError() throws Exception {
+    void prepareAndSendOutboxNotification_PushDelivery_Failure_DeletesNotification_ThrowsException() throws Exception {
         NotificationOutbox outbox = buildMockOutbox(NotificationType.LISTING_VIS_STATUS_CHANGED, DeliveryChannel.PUSH);
         GroupListing mockListing = mock(GroupListing.class);
         when(mockListing.getListingTitle()).thenReturn("Test Listing");
@@ -569,10 +571,9 @@ class NotificationServiceImplTest {
         when(pushNotificationService.sendPushNotification(eq(mockPushSub), any(String.class)))
                 .thenReturn(Map.of(ExternalNotifcationResult.FAILURE, HttpStatus.INTERNAL_SERVER_ERROR));
 
-        assertThatNoException().isThrownBy(() -> notificationService.prepareAndSendOutboxNotification(outbox));
+        assertThrows(ResponseStatusException.class, () -> notificationService.prepareAndSendOutboxNotification(outbox));
 
-        verify(noteOutbox).setStatus("PARTIAL_FAILURE");
-        verify(outboxRepo).save(noteOutbox);
+        verify(notificationRepo).delete(savedNote);
     }
 
     // ─── generateOutboxNotificationForModAction ───────────────────────────────


### PR DESCRIPTION
Change push notification failure to propagate exception back up to parent method so that the notification_outbox entity gets the correct status and the failed notification is deleted to prevent duplicate entry on db.