### PR TITLE
Fixing notification send conflicts/deduping issues

### DIFF
--- a/backend/src/main/java/com/sc_fleetfinder/fleets/DAO/GroupListingRepository.java
+++ b/backend/src/main/java/com/sc_fleetfinder/fleets/DAO/GroupListingRepository.java
@@ -21,7 +21,7 @@ public interface GroupListingRepository extends JpaRepository<GroupListing, Long
             INSERT IGNORE INTO notification_outbox (
                 event_type, entity_type, entity_id, entity_owner_id,
                 entity_new_status, payload_json, status, push_sub_id,
-                delivery_channel, sibling_key, created_at
+                delivery_channel, do_not_duplicate, sibling_key, created_at
                 )
             SELECT
                 'LISTING_ARCHIVED'                      AS event_type,
@@ -39,14 +39,15 @@ public interface GroupListingRepository extends JpaRepository<GroupListing, Long
                 'PENDING'                               AS status,
                 push.id_push_sub                        AS push_sub_id,
                 channels.delivery_channel               AS delivery_channel,
+                channels.do_not_duplicate               AS do_not_duplicate,
                 SHA2(CONCAT('LISTING_ARCHIVED', '|', 'GROUP_LISTING', '|', gl.id_group, '|', gl.id_user, '|', 'ARCHIVED'), 256) AS sibling_key,
                 NOW()                                   AS created_at
             FROM group_listing gl
             JOIN users u ON gl.id_user = u.id_user
             CROSS JOIN (
-                SELECT 'IN_APP' AS delivery_channel UNION ALL
-                SELECT 'DISCORD' UNION ALL
-                SELECT 'PUSH'
+                SELECT 'IN_APP' AS delivery_channel, 1 AS do_not_duplicate UNION ALL
+                SELECT 'DISCORD' AS delivery_channel, 1 AS do_not_duplicate UNION ALL
+                SELECT 'PUSH' AS delivery_channel, NULL AS do_not_duplicate
             ) AS channels
             LEFT JOIN push_subscription push
                 ON push.user_id = gl.id_user
@@ -90,7 +91,7 @@ public interface GroupListingRepository extends JpaRepository<GroupListing, Long
             INSERT IGNORE INTO notification_outbox (
                 event_type, entity_type, entity_id, entity_owner_id,
                 entity_new_status, payload_json, status, push_sub_id,
-                delivery_channel, sibling_key, created_at
+                delivery_channel, do_not_duplicate, sibling_key, created_at
                 )
             SELECT
                 'LISTING_VIS_STATUS_CHANGED'                AS event_type,
@@ -108,6 +109,7 @@ public interface GroupListingRepository extends JpaRepository<GroupListing, Long
                 'PENDING'                                   AS status,
                 push.id_push_sub                            AS push_sub_id,
                 channels.delivery_channel                   AS delivery_channel,
+                channels.do_not_duplicate                   AS do_not_duplicate,
                 SHA2(CONCAT('LISTING_VIS_STATUS_CHANGED', '|', 'GROUP_LISTING', '|', gl.id_group, '|', gl.id_user, '|', COALESCE(computed.entity_new_status, '')), 256) AS sibling_key,
                 NOW()                                       AS created_at
             FROM group_listing gl
@@ -129,9 +131,9 @@ public interface GroupListingRepository extends JpaRepository<GroupListing, Long
                 FROM group_listing
             ) computed ON computed.id_group = gl.id_group
             CROSS JOIN (
-                SELECT 'IN_APP' AS delivery_channel UNION ALL
-                SELECT 'DISCORD' UNION ALL
-                SELECT 'PUSH'
+                SELECT 'IN_APP' AS delivery_channel, 1 AS do_not_duplicate UNION ALL
+                SELECT 'DISCORD' AS delivery_channel, 1 AS do_not_duplicate UNION ALL
+                SELECT 'PUSH' AS delivery_channel, NULL AS do_not_duplicate
             ) AS channels
             LEFT JOIN push_subscription push
                 ON push.user_id = gl.id_user

--- a/backend/src/main/java/com/sc_fleetfinder/fleets/DAO/NewListingNotifyQueueRepository.java
+++ b/backend/src/main/java/com/sc_fleetfinder/fleets/DAO/NewListingNotifyQueueRepository.java
@@ -15,7 +15,7 @@ public interface NewListingNotifyQueueRepository extends JpaRepository<NewListin
             INSERT IGNORE INTO notification_outbox (
                         event_type, entity_type, entity_id, entity_owner_id, entity_new_status,
                         parent_entity_id, parent_entity_type, payload_json, status, push_sub_id,
-                        delivery_channel, sibling_key, created_at
+                        delivery_channel, do_not_duplicate, sibling_key, created_at
                     )
             SELECT
                 'NEW_LISTING_MATCH'             AS event_type,
@@ -35,6 +35,7 @@ public interface NewListingNotifyQueueRepository extends JpaRepository<NewListin
                 'PENDING'                       AS status,
                 push.id_push_sub                AS push_sub_id,
                 channels.delivery_channel       AS delivery_channel,
+                channels.do_not_duplicate       AS do_not_duplicate,
                 SHA2(CONCAT('NEW_LISTING_MATCH', '|', 'GROUP_LISTING', '|', gl.id_group, '|', customNote.user_id, '|', 'MATCHED'), 256) AS sibling_key,
                 NOW()                           AS created_at
             FROM new_listing_notify_queue queue
@@ -55,9 +56,9 @@ public interface NewListingNotifyQueueRepository extends JpaRepository<NewListin
                 AND (customNote.group_status_id IS NULL OR customNote.group_status_id = gl.group_status_id)
             JOIN users u ON customNote.user_id = u.id_user
             CROSS JOIN (
-                SELECT 'IN_APP'  AS delivery_channel UNION ALL
-                SELECT 'DISCORD' UNION ALL
-                SELECT 'PUSH'
+                SELECT 'IN_APP' AS delivery_channel, 1 AS do_not_duplicate UNION ALL
+                SELECT 'DISCORD' AS delivery_channel, 1 AS do_not_duplicate UNION ALL
+                SELECT 'PUSH' AS delivery_channel, NULL AS do_not_duplicate
             ) AS channels
             LEFT JOIN push_subscription push
                 ON push.user_id = u.id_user
@@ -91,8 +92,7 @@ public interface NewListingNotifyQueueRepository extends JpaRepository<NewListin
             // The push_subscription LEFT JOIN is conditioned on channels.delivery_channel = 'PUSH',
             // so it only fires for PUSH rows. IN_APP and DISCORD rows produce exactly 1 row per match
             // regardless of how many push subscriptions a user has (avoiding row multiplication).
-            // Users with multiple push subscriptions produce multiple PUSH rows; INSERT IGNORE
-            // deduplicates them — the single PUSH outbox entry is then sent to all their subscriptions.
+            // Users with multiple push subscriptions produce multiple PUSH entries.
 
     @Modifying
     @Query(value = """

--- a/backend/src/main/java/com/sc_fleetfinder/fleets/DAO/NotificationRepository.java
+++ b/backend/src/main/java/com/sc_fleetfinder/fleets/DAO/NotificationRepository.java
@@ -59,7 +59,7 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
             INSERT IGNORE INTO notification_outbox (
             event_type, entity_type, entity_id, entity_owner_id, entity_new_status,
             parent_entity_id, parent_entity_type, payload_json, status, push_sub_id,
-            delivery_channel, sibling_key, created_at
+            delivery_channel, do_not_duplicate, sibling_key, created_at
             )
             SELECT
                 'MOD_DELETE'                AS event_type,
@@ -75,19 +75,20 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
                     'targetLabel',      action.action_type,
                     'targetCreatedAt',  action.action_ts,
                     'addContext',       action.action_note
-                )                           AS payload_json,
-                'PENDING'                   AS status,
-                push.id_push_sub            AS push_sub_id,
-                channels.delivery_channel   AS delivery_channel,
+                )                               AS payload_json,
+                'PENDING'                       AS status,
+                push.id_push_sub                AS push_sub_id,
+                channels.delivery_channel       AS delivery_channel,
+                channels.do_not_duplicate       AS do_not_duplicate,
                 SHA2(CONCAT('MOD_DELETE', '|', 'LISTING_ARCHIVE', '|', action.id_archive, '|', action.id_user, '|', 'ARCHIVED'), 256) AS sibling_key,
-                NOW()                       as created_at
+                NOW()                           AS created_at
                 FROM mod_listing_action action
                 JOIN listing_archive archive ON action.id_archive = archive.id_archive
                 JOIN users u ON action.id_user = u.id_user
                 CROSS JOIN (
-                    SELECT 'IN_APP' AS delivery_channel UNION ALL
-                    SELECT 'DISCORD' UNION ALL
-                    SELECT 'PUSH'
+                    SELECT 'IN_APP' AS delivery_channel, 1 AS do_not_duplicate UNION ALL
+                    SELECT 'DISCORD' AS delivery_channel, 1 AS do_not_duplicate UNION ALL
+                    SELECT 'PUSH' AS delivery_channel, NULL AS do_not_duplicate
                 ) AS channels
                 LEFT JOIN push_subscription push
                     ON push.user_id = action.id_user

--- a/backend/src/main/java/com/sc_fleetfinder/fleets/DAO/chat/MessageRepository.java
+++ b/backend/src/main/java/com/sc_fleetfinder/fleets/DAO/chat/MessageRepository.java
@@ -28,7 +28,7 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
             INSERT IGNORE INTO notification_outbox (
             event_type, entity_type, entity_id, entity_owner_id, entity_new_status,
             parent_entity_id, parent_entity_type, payload_json, status, push_sub_id,
-            delivery_channel, sibling_key, created_at
+            delivery_channel, do_not_duplicate, sibling_key, created_at
             )
             SELECT
                 'NEW_CHAT_MESSAGE'          AS event_type,
@@ -44,30 +44,27 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
                     'targetLabel',      SUBSTRING(msg.msg_body, 1, 100),
                     'targetCreatedAt',  msg.created_at,
                     'addContext',       SUBSTRING(conv.title, 1, 64)
-                )                           AS payload_json,
-                'PENDING'                   AS status,
-                push.id_push_sub            AS push_sub_id,
-                channels.delivery_channel   AS delivery_channel,
+                )                               AS payload_json,
+                'PENDING'                       AS status,
+                push.id_push_sub                AS push_sub_id,
+                channels.delivery_channel       AS delivery_channel,
+                channels.do_not_duplicate       AS do_not_duplicate,
                 SHA2(CONCAT('NEW_CHAT_MESSAGE', '|', 'MESSAGE', '|', msg.id_msg, '|', :recipientId, '|', 'NEW MESSAGE'), 256) AS sibling_key,
-                NOW()                       AS created_at
+                NOW()                           AS created_at
             FROM message msg
             JOIN conversation conv ON msg.id_conversation = conv.id_conversation
-            LEFT JOIN notification noti ON conv.id_conversation = noti.parent_entity_id
-                AND noti.id_user = :recipientId
-                AND noti.parent_entity_type = 'CONVERSATION'
             JOIN conversation_participant parti ON conv.id_conversation = parti.id_conversation
                 AND parti.id_user = :recipientId
             JOIN users u ON :recipientId = u.id_user
             CROSS JOIN (
-                SELECT 'DISCORD' AS delivery_channel UNION ALL
-                SELECT 'PUSH'
+                SELECT 'DISCORD' AS delivery_channel, 1 AS do_not_duplicate UNION ALL
+                SELECT 'PUSH', NULL AS do_not_duplicate
             ) AS channels
             LEFT JOIN push_subscription push
                 ON push.user_id = :recipientId
                 AND channels.delivery_channel = 'PUSH'
                 AND push.social_notes_enabled = 1
             WHERE msg.id_msg = :msgId
-                AND (noti.created_at IS NULL OR noti.created_at < (NOW() - INTERVAL 20 SECOND))
                 AND (parti.last_read_message_id IS NULL OR parti.last_read_message_id < :msgId)
                 AND (
                     (channels.delivery_channel = 'DISCORD'

--- a/backend/src/main/java/com/sc_fleetfinder/fleets/entities/NotificationOutbox.java
+++ b/backend/src/main/java/com/sc_fleetfinder/fleets/entities/NotificationOutbox.java
@@ -47,6 +47,9 @@ public class NotificationOutbox {
     @NotNull(message="NotificationOutbox entity field 'delivery_channel' cannot be null.")
     private DeliveryChannel deliveryChannel;
 
+    @Column(name="do_not_duplicate", nullable = true)
+    private Integer doNotDuplicate;
+
     //name of entity type
     @Column(name="entity_type")
     @NotNull(message="NotificationOutbox field 'entityType' cannot be null.")

--- a/backend/src/main/resources/migration/V16__fix_notification_outbox_uq_add_push_sub_id.sql
+++ b/backend/src/main/resources/migration/V16__fix_notification_outbox_uq_add_push_sub_id.sql
@@ -1,0 +1,6 @@
+ALTER TABLE notification_outbox
+    DROP INDEX uq_note_outbox_event,
+    ADD COLUMN do_not_duplicate TINYINT DEFAULT 1,
+    MODIFY COLUMN push_sub_id BIGINT NULL DEFAULT NULL,
+    ADD UNIQUE KEY uq_note_outbox_push_id (sibling_key, entity_owner_id, push_sub_id),
+    ADD UNIQUE KEY uq_note_outbox_discord (sibling_key, entity_owner_id, delivery_channel, do_not_duplicate);

--- a/backend/src/test/java/com/sc_fleetfinder/fleets/integration_tests/GroupListingRepositoryScheduledQueriesIntegrationTest.java
+++ b/backend/src/test/java/com/sc_fleetfinder/fleets/integration_tests/GroupListingRepositoryScheduledQueriesIntegrationTest.java
@@ -516,9 +516,9 @@ public class GroupListingRepositoryScheduledQueriesIntegrationTest extends Abstr
     }
 
     @Test
-    void createOutboxEntries_Archive_UserWithMultiplePushSubs_DeduplicatedToOnePushEntry() {
+    void createOutboxEntries_Archive_UserWithMultiplePushSubs_ShouldGenerateMultipleEntries() {
         // given: user has 2 push subscriptions both with sys_notes_enabled = 1
-        // ON DUPLICATE KEY UPDATE should deduplicate to a single PUSH outbox entry
+        // should generate an entry for each push sub in notification_outbox
         Long userId = insertUserWithSysNotesConfig(false, false);
         insertPushSubscription(userId, true);
         insertPushSubscription(userId, true);
@@ -533,8 +533,33 @@ public class GroupListingRepositoryScheduledQueriesIntegrationTest extends Abstr
                 "SELECT COUNT(*) FROM notification_outbox WHERE entity_id = ? AND event_type = 'LISTING_ARCHIVED' AND delivery_channel = 'PUSH'",
                 Integer.class, id);
         assertAll(
-                () -> assertEquals(2, totalCount, "2 push subs should still yield only 2 total entries (1 IN_APP + 1 PUSH deduped)"),
-                () -> assertEquals(1, pushCount, "Exactly 1 PUSH entry despite 2 subscriptions (ON DUPLICATE KEY)")
+                () -> assertEquals(3, totalCount, "2 push subs should still yield 3 total entries (1 IN_APP + 2 PUSH)"),
+                () -> assertEquals(2, pushCount, "Should generate entries for both PUSH subscriptions")
+        );
+    }
+
+    @Test
+    void createOutboxEntries_Archive_UserWithMultiplePushSubs_OneEnabled_OneDisabled() {
+        // given: Single user has 2 push subscriptions, one has sysNotesEnabled, the other has them disabled
+        // should only generate an entry for the push sub with sysNotesEnabled
+        Long userId = insertUserWithSysNotesConfig(false, false);
+        insertPushSubscription(userId, true);
+        insertPushSubscription(userId, false);
+        Long id = insertListingForUser(userId, "ARCHIVED", "DATE_SUB(NOW(), INTERVAL 30 DAY)");
+
+        listingRepo.createOutboxEntriesForArchiveNotifications();
+
+        Integer totalCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM notification_outbox WHERE entity_id = ? AND event_type = 'LISTING_ARCHIVED'",
+                Integer.class, id);
+        Integer pushCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM notification_outbox WHERE entity_id = ? AND event_type = 'LISTING_ARCHIVED' AND delivery_channel = 'PUSH'",
+                Integer.class, id);
+        assertAll(
+                () -> assertEquals(2, totalCount, "2 push subs (one disabled) should still yield " +
+                        "2 total entries (1 IN_APP + 1 PUSH)"),
+                () -> assertEquals(1, pushCount, "Should generate entries for only the push sub with" +
+                        " sysNotesEnabled")
         );
     }
 
@@ -634,7 +659,7 @@ public class GroupListingRepositoryScheduledQueriesIntegrationTest extends Abstr
     }
 
     @Test
-    void createOutboxEntriesForStatusUpdates_UserWithMultiplePushSubs_OnlyOnePushEntry() {
+    void createOutboxEntriesForStatusUpdates_UserWithMultiplePushSubs_ProducesMultiplePushEntries() {
         Long userId = insertUserWithSysNotesConfig(false, false);
         insertPushSubscription(userId, true);
         insertPushSubscription(userId, true);
@@ -649,8 +674,8 @@ public class GroupListingRepositoryScheduledQueriesIntegrationTest extends Abstr
                 "SELECT COUNT(*) FROM notification_outbox WHERE entity_id = ? AND event_type = 'LISTING_VIS_STATUS_CHANGED' AND delivery_channel = 'PUSH'",
                 Integer.class, id);
         assertAll(
-                () -> assertEquals(2, totalCount, "2 push subs → 1 IN_APP + 1 PUSH (deduped)"),
-                () -> assertEquals(1, pushCount, "ON DUPLICATE KEY dedup → exactly 1 PUSH entry")
+                () -> assertEquals(3, totalCount, "2 push subs → 1 IN_APP + 2 PUSH"),
+                () -> assertEquals(2, pushCount, "Should generate both PUSH entries")
         );
     }
 }

--- a/backend/src/test/java/com/sc_fleetfinder/fleets/integration_tests/MessageRepositoryIntegrationTest.java
+++ b/backend/src/test/java/com/sc_fleetfinder/fleets/integration_tests/MessageRepositoryIntegrationTest.java
@@ -83,17 +83,6 @@ public class MessageRepositoryIntegrationTest extends AbstractIntegrationTestDB 
         );
     }
 
-    // Inserts an in-app notification linking the recipient to the conversation.
-    // createdAtExpr is a SQL expression: "DATE_SUB(NOW(), INTERVAL 10 MINUTE)" for old,
-    // "NOW()" for fresh (< 5 min — will not satisfy the query's age check).
-    private void insertNewMessageNotification(Long recipientId, Long convId, String createdAtExpr) {
-        jdbcTemplate.update(
-                "INSERT INTO notification (id_user, type, message, parent_entity_id, parent_entity_type, created_at) " +
-                "VALUES (?, 'NEW_MESSAGE', 'You have a new message', ?, 'CONVERSATION', " + createdAtExpr + ")",
-                recipientId, convId
-        );
-    }
-
     private void insertPushSubscription(Long userId, boolean socialNotesEnabled) {
         jdbcTemplate.update(
                 "INSERT INTO push_subscription (user_id, user_label, device_url, public_key, browser_secret, social_notes_enabled) " +
@@ -118,18 +107,17 @@ public class MessageRepositoryIntegrationTest extends AbstractIntegrationTestDB 
         Integer count = jdbcTemplate.queryForObject(
                 "SELECT COUNT(*) FROM notification_outbox WHERE entity_id = ? AND event_type = 'NEW_CHAT_MESSAGE'",
                 Integer.class, msgId);
-        assertEquals(0, count, "No in-app notification for conversation should produce no outbox entries");
+        assertEquals(0, count, "No external channels enabled should produce no outbox entries");
     }
 
     @Test
-    void generateExternal_OldNotification_Discord_CreatesDiscordEntry() {
-        // given: discord-enabled recipient, in-app notification older than 5 minutes
+    void generateExternal_DiscordEnabled_CreatesDiscordEntry() {
+        // given: discord-enabled recipient with no prior outbox entries for this message
         Long senderId = insertUser(false, false);
         Long recipientId = insertUser(true, true);  // discord + social_notes_enabled
         Long convId = insertConversation(senderId);
         Long msgId = insertMessage(convId, senderId);
         insertParticipant(convId, recipientId);
-        insertNewMessageNotification(recipientId, convId, "DATE_SUB(NOW(), INTERVAL 10 MINUTE)");
 
         int inserted = messageRepository.generateExternalDeliveryOutboxNotifications(recipientId, msgId);
 
@@ -147,14 +135,13 @@ public class MessageRepositoryIntegrationTest extends AbstractIntegrationTestDB 
     }
 
     @Test
-    void generateExternal_OldNotification_Discord_Idempotent_SecondCallIsNoop() {
+    void generateExternal_Discord_Idempotent_SecondCallIsNoOp() {
         // given: same setup as above — second call should not create duplicates
         Long senderId = insertUser(false, false);
         Long recipientId = insertUser(true, true);
         Long convId = insertConversation(senderId);
         Long msgId = insertMessage(convId, senderId);
         insertParticipant(convId, recipientId);
-        insertNewMessageNotification(recipientId, convId, "DATE_SUB(NOW(), INTERVAL 10 MINUTE)");
 
         messageRepository.generateExternalDeliveryOutboxNotifications(recipientId, msgId);
         messageRepository.generateExternalDeliveryOutboxNotifications(recipientId, msgId);
@@ -162,19 +149,18 @@ public class MessageRepositoryIntegrationTest extends AbstractIntegrationTestDB 
         Integer discordCount = jdbcTemplate.queryForObject(
                 "SELECT COUNT(*) FROM notification_outbox WHERE entity_id = ? AND event_type = 'NEW_CHAT_MESSAGE' AND delivery_channel = 'DISCORD'",
                 Integer.class, msgId);
-        assertEquals(1, discordCount, "Second call must not create a duplicate entry (ON DUPLICATE KEY)");
+        assertEquals(1, discordCount, "Second call must not create a duplicate entry (INSERT IGNORE)");
     }
 
     @Test
-    void generateExternal_OldNotification_Push_CreatesPushEntry() {
-        // given: push-enabled recipient, in-app notification older than 5 minutes
+    void generateExternal_PushEnabled_CreatesPushEntry() {
+        // given: push-enabled recipient
         Long senderId = insertUser(false, false);
         Long recipientId = insertUser(false, false);
         Long convId = insertConversation(senderId);
         Long msgId = insertMessage(convId, senderId);
         insertParticipant(convId, recipientId);
         insertPushSubscription(recipientId, true);  // social_notes_enabled = 1
-        insertNewMessageNotification(recipientId, convId, "DATE_SUB(NOW(), INTERVAL 10 MINUTE)");
 
         messageRepository.generateExternalDeliveryOutboxNotifications(recipientId, msgId);
 
@@ -199,7 +185,6 @@ public class MessageRepositoryIntegrationTest extends AbstractIntegrationTestDB 
         Long msgId = insertMessage(convId, senderId);
         insertParticipant(convId, recipientId);
         insertPushSubscription(recipientId, true);
-        insertNewMessageNotification(recipientId, convId, "DATE_SUB(NOW(), INTERVAL 10 MINUTE)");
 
         messageRepository.generateExternalDeliveryOutboxNotifications(recipientId, msgId);
 
@@ -220,24 +205,6 @@ public class MessageRepositoryIntegrationTest extends AbstractIntegrationTestDB 
     }
 
     @Test
-    void generateExternal_RecentNotification_NoEntry() {
-        // given: in-app notification created just now (< 5 minutes) — query excludes it
-        Long senderId = insertUser(false, false);
-        Long recipientId = insertUser(true, true);
-        Long convId = insertConversation(senderId);
-        Long msgId = insertMessage(convId, senderId);
-        insertParticipant(convId, recipientId);
-        insertNewMessageNotification(recipientId, convId, "NOW()");  // too recent
-
-        messageRepository.generateExternalDeliveryOutboxNotifications(recipientId, msgId);
-
-        Integer count = jdbcTemplate.queryForObject(
-                "SELECT COUNT(*) FROM notification_outbox WHERE entity_id = ? AND event_type = 'NEW_CHAT_MESSAGE'",
-                Integer.class, msgId);
-        assertEquals(0, count, "Notification created less than 5 minutes ago should not trigger external delivery");
-    }
-
-    @Test
     void generateExternal_RecipientAlreadyRead_NoEntry() {
         // given: recipient's last_read_message_id points to a newer message than :msgId
         // meaning they have already implicitly read the target message
@@ -248,7 +215,6 @@ public class MessageRepositoryIntegrationTest extends AbstractIntegrationTestDB 
         Long newerMsgId = insertMessage(convId, senderId);  // a newer message the recipient has read
         // recipient has read up to newerMsgId, which is > olderMsgId
         insertParticipantWithReadPointer(convId, recipientId, newerMsgId);
-        insertNewMessageNotification(recipientId, convId, "DATE_SUB(NOW(), INTERVAL 10 MINUTE)");
 
         messageRepository.generateExternalDeliveryOutboxNotifications(recipientId, olderMsgId);
 
@@ -266,7 +232,6 @@ public class MessageRepositoryIntegrationTest extends AbstractIntegrationTestDB 
         Long convId = insertConversation(senderId);
         Long msgId = insertMessage(convId, senderId);
         insertParticipant(convId, recipientId);
-        insertNewMessageNotification(recipientId, convId, "DATE_SUB(NOW(), INTERVAL 10 MINUTE)");
 
         messageRepository.generateExternalDeliveryOutboxNotifications(recipientId, msgId);
 
@@ -285,7 +250,6 @@ public class MessageRepositoryIntegrationTest extends AbstractIntegrationTestDB 
         Long msgId = insertMessage(convId, senderId);
         insertParticipant(convId, recipientId);
         insertPushSubscription(recipientId, false);  // social_notes_enabled = 0
-        insertNewMessageNotification(recipientId, convId, "DATE_SUB(NOW(), INTERVAL 10 MINUTE)");
 
         messageRepository.generateExternalDeliveryOutboxNotifications(recipientId, msgId);
 
@@ -296,9 +260,9 @@ public class MessageRepositoryIntegrationTest extends AbstractIntegrationTestDB 
     }
 
     @Test
-    void generateExternal_MultiplePushSubs_OnlyOnePushEntry() {
+    void generateExternal_MultiplePushSubs_ProducesMultipleEntries() {
         // given: 2 push subscriptions both with social_notes_enabled = 1
-        // ON DUPLICATE KEY UPDATE should deduplicate to exactly 1 PUSH outbox entry
+        // each produces its own PUSH outbox entry (different push_sub_id)
         Long senderId = insertUser(false, false);
         Long recipientId = insertUser(false, false);
         Long convId = insertConversation(senderId);
@@ -306,13 +270,31 @@ public class MessageRepositoryIntegrationTest extends AbstractIntegrationTestDB 
         insertParticipant(convId, recipientId);
         insertPushSubscription(recipientId, true);
         insertPushSubscription(recipientId, true);
-        insertNewMessageNotification(recipientId, convId, "DATE_SUB(NOW(), INTERVAL 10 MINUTE)");
 
         messageRepository.generateExternalDeliveryOutboxNotifications(recipientId, msgId);
 
         Integer pushCount = jdbcTemplate.queryForObject(
                 "SELECT COUNT(*) FROM notification_outbox WHERE entity_id = ? AND event_type = 'NEW_CHAT_MESSAGE' AND delivery_channel = 'PUSH'",
                 Integer.class, msgId);
-        assertEquals(1, pushCount, "2 push subscriptions should still produce exactly 1 PUSH entry (ON DUPLICATE KEY dedup)");
+        assertEquals(2, pushCount, "2 push subscriptions should produce exactly 2 PUSH entries");
+    }
+
+    @Test
+    void generateExternal_MultiplePushSubs_OneWithSocialNotesDisabled_ProducesSingleEntry() {
+        // given: 2 push subscriptions, one with social_notes_enabled = 0
+        Long senderId = insertUser(false, false);
+        Long recipientId = insertUser(false, false);
+        Long convId = insertConversation(senderId);
+        Long msgId = insertMessage(convId, senderId);
+        insertParticipant(convId, recipientId);
+        insertPushSubscription(recipientId, false);
+        insertPushSubscription(recipientId, true);
+
+        messageRepository.generateExternalDeliveryOutboxNotifications(recipientId, msgId);
+
+        Integer pushCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM notification_outbox WHERE entity_id = ? AND event_type = 'NEW_CHAT_MESSAGE' AND delivery_channel = 'PUSH'",
+                Integer.class, msgId);
+        assertEquals(1, pushCount, "Only the enabled push subscription should produce a PUSH entry");
     }
 }

--- a/backend/src/test/java/com/sc_fleetfinder/fleets/integration_tests/NewListingNotifyQueueRepositoryIntegrationTest.java
+++ b/backend/src/test/java/com/sc_fleetfinder/fleets/integration_tests/NewListingNotifyQueueRepositoryIntegrationTest.java
@@ -379,8 +379,9 @@ public class NewListingNotifyQueueRepositoryIntegrationTest extends AbstractInte
     }
 
     @Test
-    void generateOutbox_UserWithMultiplePushSubs_OnlyOnePushEntry() {
-        // Two push subscriptions both with group_notes_enabled=1; ON DUPLICATE KEY deduplicates to 1
+    void generateOutbox_UserWithMultiplePushSubs_ProducesMultipleEntries() {
+        // Two push subscriptions both with group_notes_enabled=1; on duplicate key should allow multiple push sub notes
+        // for a single event
         Long ownerId = insertUser(false, false);
         Long receiverId = insertUser(false, false);
         Long listingId = insertListing(ownerId);
@@ -398,8 +399,8 @@ public class NewListingNotifyQueueRepositoryIntegrationTest extends AbstractInte
                 "SELECT COUNT(*) FROM notification_outbox WHERE entity_id = ? AND event_type = 'NEW_LISTING_MATCH' AND delivery_channel = 'PUSH'",
                 Integer.class, listingId);
         assertAll(
-                () -> assertEquals(2, totalCount, "2 push subs → 1 IN_APP + 1 PUSH (deduped via ON DUPLICATE KEY)"),
-                () -> assertEquals(1, pushCount, "Exactly 1 PUSH entry despite 2 subscriptions")
+                () -> assertEquals(3, totalCount, "2 push subs → 1 IN_APP + 2 PUSH"),
+                () -> assertEquals(2, pushCount, "Exactly 2 PUSH entries when 2 subscriptions are active")
         );
     }
 

--- a/backend/src/test/java/com/sc_fleetfinder/fleets/integration_tests/NotificationRepositoryIntegrationTest.java
+++ b/backend/src/test/java/com/sc_fleetfinder/fleets/integration_tests/NotificationRepositoryIntegrationTest.java
@@ -247,7 +247,7 @@ public class NotificationRepositoryIntegrationTest extends AbstractIntegrationTe
     @Test
     void generateOutbox_ModDelete_MultiplePushSubs_OnlyOnePushEntry() {
         // given: 2 push subscriptions both with sys_notes_enabled = 1
-        // ON DUPLICATE KEY UPDATE should deduplicate to exactly 1 PUSH outbox entry
+        // ON DUPLICATE KEY UPDATE should generate 2 outbox entries
         Long ownerId = insertUser(false, false);
         insertPushSubscription(ownerId, true);
         insertPushSubscription(ownerId, true);
@@ -263,8 +263,8 @@ public class NotificationRepositoryIntegrationTest extends AbstractIntegrationTe
                 "SELECT COUNT(*) FROM notification_outbox WHERE parent_entity_id = ? AND event_type = 'MOD_DELETE' AND delivery_channel = 'PUSH'",
                 Integer.class, actionId);
         assertAll(
-                () -> assertEquals(2, totalCount, "2 push subs should still yield 2 total entries (1 IN_APP + 1 PUSH deduped)"),
-                () -> assertEquals(1, pushCount, "Exactly 1 PUSH entry despite 2 subscriptions (ON DUPLICATE KEY)")
+                () -> assertEquals(3, totalCount, "2 push subs should still yield 2 total entries (1 IN_APP + 1 PUSH deduped)"),
+                () -> assertEquals(2, pushCount, "Exactly 1 PUSH entry despite 2 subscriptions (ON DUPLICATE KEY)")
         );
     }
 

--- a/backend/src/test/resources/application-test.properties
+++ b/backend/src/test/resources/application-test.properties
@@ -5,8 +5,6 @@ spring.application.name=FleetsApplicationTests
 #spring.datasource.username=${DB_USERNAME}
 #spring.datasource.password=${DB_PASSWORD}
 
-spring.task.scheduling.pool.size=1
-
 ##repository detection strategy
 spring.data.rest.detection-strategy=ANNOTATED
 


### PR DESCRIPTION
Fix unintentional deduping of multiple push notifications per user per event. Added a unique key on sibling_key, user_id, and push_sub_id to allow multiple outbox notifications to be created for a user with multiple push subscriptions. This does not block discord or in_app though because null registers as unique. So added a 'do_not_duplicate' column that must be set to null for PUSH notifications and 1 for IN_APP or DISCORD notifications.