### PR TITLE
 Resolving issues with account deletion errors and discord account link removal.

### DIFF
--- a/backend/src/main/java/com/sc_fleetfinder/fleets/config/KeycloakAdminProperties.java
+++ b/backend/src/main/java/com/sc_fleetfinder/fleets/config/KeycloakAdminProperties.java
@@ -12,6 +12,6 @@ public class KeycloakAdminProperties {
     private String clientSecret;
     private String realm;
     private String serverUrl;
-    private String frontendBaseUrl;
+    private String publicUrl;
     private String frontendClientId;
 }

--- a/backend/src/main/java/com/sc_fleetfinder/fleets/config/WebSocketConfig.java
+++ b/backend/src/main/java/com/sc_fleetfinder/fleets/config/WebSocketConfig.java
@@ -16,7 +16,8 @@ import org.springframework.web.socket.config.annotation.WebSocketTransportRegist
 @Profile("!test")
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
-    @Value("${app.ws.allowed-origins}")
+    //WebSockets allowed origins is base url
+    @Value("${app.frontend-base-url}")
     private String wsAppUrl;
 
     private final StompJwtChannelInterceptor stompJwtChannelInterceptor;

--- a/backend/src/main/java/com/sc_fleetfinder/fleets/services/CRUD_services/GroupListingServiceImpl.java
+++ b/backend/src/main/java/com/sc_fleetfinder/fleets/services/CRUD_services/GroupListingServiceImpl.java
@@ -138,8 +138,6 @@ public class GroupListingServiceImpl implements GroupListingService {
                 GroupListing listingWithId = groupListingRepository.save(groupListing);
                 groupListingRepository.flush();
 
-                log.info("id: {}", listingWithId.getGroupId());
-
                 NewListingNotifyQueue queued = new NewListingNotifyQueue(listingWithId);
 
                 listingNotifyQueueRepository.save(queued);

--- a/backend/src/main/java/com/sc_fleetfinder/fleets/services/CRUD_services/NotificationServiceImpl.java
+++ b/backend/src/main/java/com/sc_fleetfinder/fleets/services/CRUD_services/NotificationServiceImpl.java
@@ -271,7 +271,7 @@ public class NotificationServiceImpl implements NotificationService {
 
     private Notification buildNewListingMatchNotification(NotificationOutbox outboxEntity) {
         String title = "Your custom notification '" + outboxEntity.getPayloadJson().getNoteTopic() + "' " +
-                "matched a new listing:";
+                "matched a new listing";
 
         String message = outboxEntity.getPayloadJson().getTargetLabel();
 
@@ -289,7 +289,7 @@ public class NotificationServiceImpl implements NotificationService {
     }
 
     private Notification buildListingStatusChangeNotification(NotificationOutbox outboxEntity) {
-        String title = "The status of one of your listings has changed to: " +
+        String title = "The status of one of your listings has changed to " +
                 outboxEntity.getEntityNewStatus();
 
         String msg = groupListingRepository.findById(outboxEntity.getEntityId())
@@ -332,7 +332,7 @@ public class NotificationServiceImpl implements NotificationService {
     }
 
     private Notification buildModDeleteNotification(NotificationOutbox outboxEntity) {
-        String title = "One of your listings was removed by a moderator.";
+        String title = "One of your listings was removed by a moderator";
         String msg = modActionRepo.findById(outboxEntity.getParentEntityId())
                 .map(ModListingAction::getActionBasis)
                 .map(ListingReportBasis::getBasisLabel)

--- a/backend/src/main/java/com/sc_fleetfinder/fleets/services/Keycloak_Services/KeycloakAdminServiceImpl.java
+++ b/backend/src/main/java/com/sc_fleetfinder/fleets/services/Keycloak_Services/KeycloakAdminServiceImpl.java
@@ -4,6 +4,7 @@ import com.sc_fleetfinder.fleets.config.KeycloakAdminProperties;
 import com.sc_fleetfinder.fleets.events.UserRemoveDiscLinkEvent;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.event.EventListener;
 import org.springframework.core.env.Environment;
 import org.springframework.http.HttpEntity;
@@ -16,8 +17,6 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
-import javax.crypto.Mac;
-import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.HashMap;
@@ -29,14 +28,15 @@ import java.util.Base64;
 @Slf4j
 public class KeycloakAdminServiceImpl implements KeycloakAdminService {
 
+    @Value("${app.frontend-base-url}")
+    private String frontendBaseUrl;
+
     private final KeycloakAdminProperties props;
     private final RestTemplate restTemplate;
-    private final Environment environment;
 
-    public KeycloakAdminServiceImpl(KeycloakAdminProperties props, RestTemplate restTemplate, Environment environment) {
+    public KeycloakAdminServiceImpl(KeycloakAdminProperties props, RestTemplate restTemplate) {
         this.props = props;
         this.restTemplate = restTemplate;
-        this.environment = environment;
     }
 
     private String getAdminToken() {
@@ -72,7 +72,7 @@ public class KeycloakAdminServiceImpl implements KeycloakAdminService {
     public String generateDiscordKeycloakLink(String sessionState) {
         String nonce = UUID.randomUUID().toString();
 
-        String redirectUri = props.getFrontendBaseUrl() + "/user-account";
+        String redirectUri = frontendBaseUrl + "/user-account";
         String identityProvider = "discord";
 
         String combine = nonce + sessionState + props.getFrontendClientId() + identityProvider;
@@ -83,7 +83,7 @@ public class KeycloakAdminServiceImpl implements KeycloakAdminService {
         byte[] check = md.digest(combine.getBytes(StandardCharsets.UTF_8));
         String hash = Base64.getUrlEncoder().withoutPadding().encodeToString(check);
 
-        return props.getServerUrl() + "/realms/" + props.getRealm() + "/broker/"
+        return props.getPublicUrl() + "/realms/" + props.getRealm() + "/broker/"
                 + identityProvider + "/link?client_id=" + props.getFrontendClientId()
                 + "&redirect_uri=" + redirectUri + "&nonce=" + nonce
                 + "&hash=" + hash;

--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -34,11 +34,11 @@ keycloak.admin.client-id=dev-backend-service
 keycloak.admin.client-secret=${KEYCLOAK_ADMIN_CLIENT_SECRET}
 keycloak.admin.realm=oauthrealm
 keycloak.admin.server-url=http://localhost:8180
-keycloak.admin.frontend-base-url=http://localhost:4200
+keycloak.admin.public-url=http://localhost:8180
 keycloak.admin.frontend-client-id=${KEYCLOAK_FRONTEND_CLIENT_ID}
 
 # WebSockets
-app.ws.allowed-origins=${WS_ALLOWED_ORIGINS}
+app.frontend-base-url=${FRONTEND_BASE_URL}
 
 # Discord Bot
 discord.bot.token=${DISCORD_BOT_TOKEN}

--- a/backend/src/main/resources/application-prod.properties
+++ b/backend/src/main/resources/application-prod.properties
@@ -21,15 +21,25 @@ spring.jpa.properties.hibernate.default_batch_fetch_size=20
 # Keycloak
 spring.security.oauth2.resourceserver.jwt.issuer-uri = https://scfleetfinder.com/auth/realms/oauthrealm
 
+# keycloak public url is for generating links to send to the frontend.
+# it is the same as admin server url in dev (BUT NOT PROD) because
+# the backend does not run in a container in dev and does not have the NGINX proxy routing traffic.
+# prod needs different public and server urls because backend and keycloak are both running in containers
+# on the same network, communication that stays in the network does not go through nginx so the
+# admin.server-url for generating tokens for the backend to authenticate with keycloak needs to be the
+# internal port. Whereas links that are generated  and sent to the frontend need the public url because they
+# need to route from an external source through NGINX.
+# keycloak.admin.frontend-base-url is just the base url used for rerouting after keycloak (back to the app)
+
 keycloak.admin.client-id=${KC_ADMIN_CLIENT_ID}
 keycloak.admin.client-secret=${KC_ADMIN_CLIENT_SECRET}
 keycloak.admin.realm=oauthrealm
 keycloak.admin.server-url=${KC_ADMIN_SERVER_URL}
-keycloak.admin.frontend-base-url=${FRONTEND_BASE_URL}
+keycloak.admin.public-url=${KC_ADMIN_PUBLIC_URL}
 keycloak.admin.frontend-client-id=${KC_FRONTEND_CLIENT_ID}
 
 # WebSockets
-app.ws.allowed-origins=${WS_ALLOWED_ORIGINS}
+app.frontend-base-url=${FRONTEND_BASE_URL}
 
 # Discord Bot
 discord.bot.token=${DISCORD_BOT_TOKEN}

--- a/backend/src/main/resources/keycloak/dev-realm-export.json
+++ b/backend/src/main/resources/keycloak/dev-realm-export.json
@@ -755,7 +755,7 @@
       "attributes": {
         "realm_client": "false",
         "oidc.ciba.grant.enabled": "false",
-        "client.secret.creation.time": "1773455124",
+        "client.secret.creation.time": "1774721943",
         "backchannel.logout.session.required": "true",
         "standard.token.exchange.enabled": "false",
         "post.logout.redirect.uris": "+",
@@ -1781,7 +1781,7 @@
     {
       "alias": "discord",
       "displayName": "",
-      "internalId": "96709ff1-f23d-46b9-b5ce-477352765873",
+      "internalId": "21d12fb5-da59-4403-b5e2-db9ffd00dce6",
       "providerId": "oidc",
       "enabled": true,
       "updateProfileFirstLoginMode": "on",
@@ -1806,7 +1806,6 @@
         "syncMode": "FORCE",
         "clientSecret": "**********",
         "allowedClockSkew": "0",
-        "defaultScope": "identify email",
         "userInfoUrl": "https://discord.com/api/oauth2/userinfo",
         "validateSignature": "true",
         "clientId": "1481092992864485528",
@@ -1826,8 +1825,8 @@
   ],
   "identityProviderMappers": [
     {
-      "id": "a05a7b3d-4842-4822-89a0-d9391e906062",
-      "name": "discord-user-id-to-email",
+      "id": "113e9803-43f5-45cb-b44c-9968aa48d1c1",
+      "name": "discord-user-id-to-fleetfinder-discord-user-id",
       "identityProviderAlias": "discord",
       "identityProviderMapper": "oidc-user-attribute-idp-mapper",
       "config": {
@@ -1837,7 +1836,7 @@
       }
     },
     {
-      "id": "a7823de8-b1a7-4449-b86d-a690730b1bef",
+      "id": "50675b9d-e671-4b62-b909-0b557d8cbf54",
       "name": "discord-username-to-fleetfinder-username",
       "identityProviderAlias": "discord",
       "identityProviderMapper": "oidc-user-attribute-idp-mapper",

--- a/backend/src/test/resources/application-test.properties
+++ b/backend/src/test/resources/application-test.properties
@@ -24,6 +24,8 @@ spring.data.rest.base-path=/testApi
 
 allowed.origins=*
 
+app.frontend-base-url=http://localhost:4200
+
 discord.bot.token=TEST_DISCORD_BOT_TOKEN
 
 vapid.public.key=TEST_VAPID_PUBLIC_KEY


### PR DESCRIPTION
Fix discord removal request link generation by adding a new public url, wasnt necessary in dev because it was the same as admin server url due to no nginx and backend not running in a container in dev. Add new .app-frontend-base-url variable to test.properties.